### PR TITLE
updated matplotlib inline and import to work on mac

### DIFF
--- a/01-Array.ipynb
+++ b/01-Array.ipynb
@@ -441,8 +441,8 @@
    },
    "outputs": [],
    "source": [
-    "from matplotlib import pyplot as plt\n",
     "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "fig = plt.figure(figsize=(16, 8))\n",
     "plt.imshow(dsets[0][::4, ::4], cmap='RdBu_r')"
@@ -645,21 +645,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Reverses the %matplotlib inline magic and import statement (required on mac).

Note that I'm also using Python 3 and a newer version of IPython.
