### PR TITLE
Replace outdated _visualize() calls with visualize()

### DIFF
--- a/03a-DataFrame.ipynb
+++ b/03a-DataFrame.ipynb
@@ -116,7 +116,7 @@
    },
    "outputs": [],
    "source": [
-    "df._visualize()"
+    "df.visualize()"
    ]
   },
   {
@@ -127,7 +127,7 @@
    },
    "outputs": [],
    "source": [
-    "df.amount.sum()._visualize()"
+    "df.amount.sum().visualize()"
    ]
   },
   {


### PR DESCRIPTION
`_visualize()` no longer works with current versions of dask.