### PR TITLE
Make filename in text match that in code

### DIFF
--- a/02_foundations.ipynb
+++ b/02_foundations.ipynb
@@ -315,7 +315,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This directory contains a file called `Dockerfile`. How would you count the number of words in that file?\n",
+    "This directory contains a file called `README.md`. How would you count the number of words in that file?\n",
     "\n",
     "The simplest approach would be to load all the data into memory, split on whitespace and count the number of results. Here we use a regular expression to split words."
    ]


### PR DESCRIPTION
The text mentions `Dockerfile`, but the two code blocks that follow operate on `README.md` instead. Make the text match the code.