### PR TITLE
replace code cell with markdown

### DIFF
--- a/02_foundations.ipynb
+++ b/02_foundations.ipynb
@@ -232,13 +232,13 @@
    ]
   },
   {
-   "cell_type": "code",
+   "cell_type": "markdown",
    "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
-   "source": [
+   "source": [```python
     "from dask.multiprocessing import get\n",
     "\n",
     "delayed_read_csv = delayed(pd.read_csv)\n",
@@ -249,7 +249,7 @@
     "\n",
     "# execute with multiprocessing scheduler\n",
     "%time total.compute(get=get)   "
-   ]
+   ```]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Small change in tutorial. 
Change cell that has example code with elypsis "..." from code to markdown to prevent it from raising an error. 

use ```python and markdown cell for code example that shouldn't run.