### PR TITLE
scikit-image compat

### DIFF
--- a/prep.py
+++ b/prep.py
@@ -73,7 +73,7 @@ def create_weather(growth=32):
         with h5py.File(fn, mode='r') as f:
             x = f['/t2m'][:]
 
-        y = resize(x, (x.shape[0] * 32, x.shape[1] * 32))
+        y = resize(x, (x.shape[0] * 32, x.shape[1] * 32), mode='constant')
 
         out_fn = os.path.join('data', 'weather-big', os.path.split(fn)[-1])
 


### PR DESCRIPTION
The default is changing in the future. This produced a warning when running prep.py