### PR TITLE
Keep to py36 for now

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3
+  - python=3.6
   - numpy
   - h5py
   - scipy


### PR DESCRIPTION
@bmcguirk , please check with this env - python is fixed to v36.
 
Ref: https://github.com/dask/dask-tutorial/issues/78