### PR TITLE
Add start

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,1 +1,0 @@
-python prep.py

--- a/start
+++ b/start
@@ -1,0 +1,4 @@
+
+cd dask-tutorial 
+python prep.py > prep-download-data.log &.
+cd ..


### PR DESCRIPTION
PR adds the prep download to a start file.  This file is executed just before the session starts.  With tips from @djhoese and @jhamman the prep download is put into the background and the session starts cleanly.  Probably after 5-10minutes the data will be fully populated