### PR TITLE
use markdown for gif

### DIFF
--- a/01x_lazy.ipynb
+++ b/01x_lazy.ipynb
@@ -148,7 +148,7 @@
     "\n",
     "With `delayed` and normal pythonic looped code, very complex graphs can be built up and passed on to Dask for execution. See a nice example of [simulated complex ETL](http://matthewrocklin.com/blog/work/2017/01/24/dask-custom) work flow.\n",
     "\n",
-    "<img src=\"images/grid_search_schedule.gif\">"
+    "![this](images/grid_search_schedule.gif)"
    ]
   },
   {
@@ -209,9 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "```python\n",
     "delayed_read_csv = delayed(pd.read_csv)\n",
@@ -553,9 +551,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Resolves #121 

Don't exactly know why but converting to markdown seems to have fixed the issue:

From local build log:

```
Generating indices... genindex
writing additional pages... search
copying images... [ 33%] images/grid_search_schedule.gif
copying images... [ 66%] images/tasks.png
copying images... [100%] images/merged_grid_search_graph.svg
```

I think I saw something in `docutilis` which checks for `alt text` when parsing docs --this is added when using markdown