### PR TITLE
Restore 07_dataframe_storage.ipynb to valid JSON

### DIFF
--- a/07_dataframe_storage.ipynb
+++ b/07_dataframe_storage.ipynb
@@ -267,7 +267,7 @@
    "outputs": [],
    "source": [
     "target = os.path.join('data', 'accounts.parquet')\n",
-    "df_csv.categorize(columns=['names']).to_parquet(target, storage_options={"has_nulls": True}, engine="fastparquet")"
+    "df_csv.categorize(columns=['names']).to_parquet(target, storage_options={\"has_nulls\": True}, engine=\"fastparquet\")"
    ]
   },
   {


### PR DESCRIPTION
Escape quotes in cell with call to .to_parquet()