### PR TITLE
Lower heading level in dask delayed notebook

### DIFF
--- a/01_dask.delayed.ipynb
+++ b/01_dask.delayed.ipynb
@@ -717,7 +717,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Close the Client\n",
+    "## Close the Client\n",
     "\n",
     "Before moving on to the next exercise, make sure to close your client or stop this kernel."
    ]


### PR DESCRIPTION
This section heading is showing up in the toctree

<img width="292" alt="Screen Shot 2019-12-20 at 1 36 18 PM" src="https://user-images.githubusercontent.com/11656932/71287353-c98a3580-232d-11ea-9a53-dc7275d38258.png">
