### PR TITLE
Bump jupyterlab and dask-labextension to 2.x

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,14 +4,14 @@ channels:
 dependencies:
   - python=3.7
   - nodejs
-  - jupyterlab>=1.0
+  - jupyterlab>=2.0
   - numpy>=1.18.1
   - h5py
   - scipy>=1.3.0
   - toolz
   - bokeh>=1.4.0
   - dask=2.11.0
-  - dask-labextension>=1.0.3
+  - dask-labextension>=2.0.0
   - distributed=2.11.0
   - notebook
   - matplotlib


### PR DESCRIPTION
This PR bumps both Jupyterlab and dask-labextension to their latest releases (2.0.0).
