### PR TITLE
remove unused import in prep.py

### DIFF
--- a/prep.py
+++ b/prep.py
@@ -7,7 +7,6 @@ import json
 import gzip
 import tarfile
 import urllib.request
-import zipfile
 
 import h5py
 import numpy as np


### PR DESCRIPTION
I think that `zipfile` is unused in `prep.py`, and I'd like to propose removing it.