### PR TITLE
add dask-worker-space to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ data/flightjson
 data/nycflights
 data/myfile.zarr
 data/accounts.parquet
-**/dask-worker-space
+dask-worker-space/
 profile.html
 log
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ data/flightjson
 data/nycflights
 data/myfile.zarr
 data/accounts.parquet
+**/dask-worker-space
 profile.html
 log
 .idea/


### PR DESCRIPTION
Thanks for these tutorials!

I found that one of them creates a directory `dask-worker-space`. I think that's coming from [`distributed.worker`](https://distributed.dask.org/en/latest/_modules/distributed/worker.html).

In this PR, I propose adding it to `.gitignore`.