### PR TITLE
Update scheduler demo to illustrate performance differences

### DIFF
--- a/05_distributed.ipynb
+++ b/05_distributed.ipynb
@@ -90,7 +90,7 @@
     "    t0 = time.time()\n",
     "    r = largest_delay.compute(scheduler=sch)\n",
     "    t1 = time.time()\n",
-    "    print(f\"{sch:>10}, {t1 - t0:0.4f}; result, {r}\")"
+    "    print(f\"{sch:>10}, {t1 - t0:0.4f} s; result, {r:0.2f} hours\")"
    ]
   },
   {

--- a/05_distributed.ipynb
+++ b/05_distributed.ipynb
@@ -72,8 +72,8 @@
     "                        'CRSElapsedTime': float,\n",
     "                        'Cancelled': bool})\n",
     "\n",
-    "# Maximum non-cancelled delay\n",
-    "largest_delay = df[~df.Cancelled].DepDelay.max()\n",
+    "# Maximum average non-cancelled delay grouped by Airport\n",
+    "largest_delay = df[~df.Cancelled].groupby('Origin').DepDelay.mean().max()\n",
     "largest_delay"
    ]
   },
@@ -88,9 +88,9 @@
     "import time\n",
     "for sch in ['threading', 'processes', 'sync']:\n",
     "    t0 = time.time()\n",
-    "    _ = largest_delay.compute(scheduler=sch)\n",
+    "    r = largest_delay.compute(scheduler=sch)\n",
     "    t1 = time.time()\n",
-    "    print(f\"{sch:>10}, {t1 - t0:0.4f}\")"
+    "    print(f\"{sch:>10}, {t1 - t0:0.4f}; result, {r}\")"
    ]
   },
   {


### PR DESCRIPTION
The scheduler performance example in notebook 8 is showing different times than expected with the latest version of Dask. 
This cause the last 2 "questions to consider" to be confusing, since processes are faster than threads. I'm not sure why?

> ### Some Questions to Consider:
> - How much faster was using threads over a single thread? Why does this differ from the optimal speedup?
> - Why is the multiprocessing scheduler so much slower here?

## Original Example and Results
```
import dask.dataframe as dd
import os
df = dd.read_csv(os.path.join('data', 'nycflights', '*.csv'),
                 parse_dates={'Date': [0, 1, 2]},
                 dtype={'TailNum': object,
                        'CRSElapsedTime': float,
                        'Cancelled': bool})

# Maximum non-cancelled delay
largest_delay = df[~df.Cancelled].DepDelay.max()
largest_delay
```
```
# each of the following gives the same results (you can check!)
# any surprises?
import time
for sch in ['threading', 'processes', 'sync']:
    t0 = time.time()
    _ = largest_delay.compute(scheduler=sch)
    t1 = time.time()
    print(f"{sch:>10}, {t1 - t0:0.4f}")
```
Output (from my mac):
```
 threading, 3.3360
 processes, 1.6513
      sync, 5.3507
```

## Updated DataFrame Computation

This PR updates the dateframe computation to illustrate the point with expected relative times.

```
# Maximum average non-cancelled delay grouped by Airport
largest_delay = df[~df.Cancelled].groupby('Origin').DepDelay.mean().max()
```
Output:
```
 threading, 3.4454 s; result, 10.35 hours
 processes, 43.7304 s; result, 10.35 hours
      sync, 4.9558 s; result, 10.35 hours
```