### PR TITLE
Bump Python to 3.8 and Dask to 2.20.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: dask-tutorial
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.8
   - nodejs
   - jupyterlab>=2.0.0
   - numpy>=1.18.1
@@ -10,9 +10,9 @@ dependencies:
   - scipy>=1.3.0
   - toolz
   - bokeh>=2.0.0
-  - dask=2.11.0
+  - dask=2.20.0
   - dask-labextension>=2.0.0
-  - distributed=2.11.0
+  - distributed=2.20.0
   - notebook
   - matplotlib
   - Pillow


### PR DESCRIPTION
This PR updates Python and Dask to the latest supported releases 