### PR TITLE
Delayed uses multi-threaded scheduler by default

### DIFF
--- a/01_dask.delayed.ipynb
+++ b/01_dask.delayed.ipynb
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "# This actually runs our computation using a local process pool\n",
+    "# This actually runs our computation using a local thread pool\n",
     "\n",
     "z.compute()"
    ]


### PR DESCRIPTION
This PR updates a comment in the delayed notebook to indicate that `dask.delayed` uses the multi-threading scheduler by default (xref https://github.com/dask/dask/blob/7d09b9e505a2686d425b5fa240526583a250e62a/dask/delayed.py#L492) 