### PR TITLE
Fix Remove processes=False for Client

### DIFF
--- a/03_array.ipynb
+++ b/03_array.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "from dask.distributed import Client\n",
     "\n",
-    "client = Client(n_workers=4, processes=False)"
+    "client = Client(n_workers=4)"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ From the repo directory
 
     jupyter notebook 
 
+Or
+
+    jupyter lab
+
 This was already done for method c) and does not need repeating.
 
 ## Links


### PR DESCRIPTION
Fixes issue with running locally using the large weather dataset, process=False results in a multithreaded implementation according to the LocalCluster docs. This creates a lot of memory warning due to the overhead on the single process memory limit, whereas removing this results in a nice chew through the dataset with no warnings... 

Hope this suggestion helps! I suspect this would have solved a lot of chatter about speed/warnings in the live tutorial :-)