### PR TITLE
01x_lazy: typo in delayed execution

### DIFF
--- a/01x_lazy.ipynb
+++ b/01x_lazy.ipynb
@@ -529,7 +529,7 @@
     "    res = x\n",
     "    yield res\n",
     "    res += y\n",
-    "    yield y\n",
+    "    yield res\n",
     "\n",
     "g = gen()"
    ]


### PR DESCRIPTION
In part 3, delayed execution, the generator said 'yield y' when it should have said 'yield res'.