### PR TITLE
Docker bug fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,22 @@ RUN git clone https://github.com/dask/dask-tutorial.git ./dask-tutorial
 RUN cd dask-tutorial && conda env update -f binder/environment.yml && . binder/postBuild && cd ..
 RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
 
-RUN echo "source activate dask-tutorial" > ~/.bashrc
+# The notebooks are configured to use kernel python3
+# We want them to use the kernel dask-tutorial
+# So we switch kernels
+
+SHELL ["conda","run","-n","dask-tutorial","/bin/bash","-c"]
+RUN jupyter kernelspec remove -f python3
+RUN python -m ipykernel install --user --name python3 --display-name "Python 3"
+
+# Shell into the container takes us to the correct environment
+
+RUN conda init
+RUN echo "conda activate dask-tutorial" >> ~/.bashrc
+
+# If we do not launch jupyter using the correct environment it
+# leads to a failure to list clusters suggesting to check if extensions
+# are installed/enabled
+
 ENV PATH /opt/conda/envs/dask-tutorial/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,7 @@ USER jovyan
 RUN git clone https://github.com/dask/dask-tutorial.git ./dask-tutorial
 RUN cd dask-tutorial && conda env update -f binder/environment.yml && . binder/postBuild && cd ..
 RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
+
+RUN echo "source activate dask-tutorial" > ~/.bashrc
+ENV PATH /opt/conda/envs/dask-tutorial/bin:$PATH
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,11 @@
-FROM jupyter/scipy-notebook:1386e2046833
+FROM jupyter/base-notebook:lab-2.2.5
 
 USER root
 # python3 setup
-RUN apt-get update && apt-get install -y graphviz
+RUN apt-get update && apt-get install -y graphviz git
 
 USER jovyan
 
 RUN git clone https://github.com/dask/dask-tutorial.git ./dask-tutorial
-RUN cd dask-tutorial && conda env update -f binder/environment.yml && cd ..
+RUN cd dask-tutorial && conda env update -n base -f binder/environment.yml --prune && . binder/postBuild && cd ..
 RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
-
-# The notebooks are configured to use kernel python3
-# We want them to use the kernel dask-tutorial
-# So we switch kernels
-
-SHELL ["conda","run","-n","dask-tutorial","/bin/bash","-c"]
-RUN . dask-tutorial/binder/postBuild
-RUN jupyter kernelspec remove -f python3
-RUN python -m ipykernel install --user --name python3 --display-name "Python 3"
-
-# Shell into the container takes us to the correct environment
-
-RUN conda init
-RUN echo "conda activate dask-tutorial" >> ~/.bashrc
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y graphviz
 USER jovyan
 
 RUN git clone https://github.com/dask/dask-tutorial.git ./dask-tutorial
-RUN cd dask-tutorial && conda env update -f binder/environment.yml && . binder/postBuild && cd ..
+RUN cd dask-tutorial && conda env update -f binder/environment.yml && cd ..
 RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
 
 # The notebooks are configured to use kernel python3
@@ -15,6 +15,7 @@ RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
 # So we switch kernels
 
 SHELL ["conda","run","-n","dask-tutorial","/bin/bash","-c"]
+RUN . dask-tutorial/binder/postBuild
 RUN jupyter kernelspec remove -f python3
 RUN python -m ipykernel install --user --name python3 --display-name "Python 3"
 
@@ -22,10 +23,4 @@ RUN python -m ipykernel install --user --name python3 --display-name "Python 3"
 
 RUN conda init
 RUN echo "conda activate dask-tutorial" >> ~/.bashrc
-
-# If we do not launch jupyter using the correct environment it
-# leads to a failure to list clusters suggesting to check if extensions
-# are installed/enabled
-
-ENV PATH /opt/conda/envs/dask-tutorial/bin:$PATH
 


### PR DESCRIPTION
The Dockerfile was creating an environment dask-tutorial but then launching jupyter using the default one.

This causes two issues:

1.  

![Screenshot from 2020-09-23 12-43-45](https://user-images.githubusercontent.com/8229727/94002639-72246480-fd9a-11ea-90a3-c32900179499.png)

2. Since the notebooks were not using the correct kernel, all packages used were not available and in particular graphviz was not available as pointed out in this [issue](https://github.com/dask/dask-tutorial/issues/139).

I fix that in this PR. It is not as straightforward as running `conda init` and the `conda activate environment` as the former requires to launch a new shell which is not possible. 

The solution is to shell into the correct environment and then run the postBuild script. Furthermore, the notebooks are configured to use the environment python3. This can be solved simply by pointing python3 to dask-tutorial as I have done.

In addition I also make some changes to make sure that logging into a shell in the container activates the correct environment.



