### PR TITLE
Configure dashboard to display proxied link

### DIFF
--- a/.dask/config.yaml
+++ b/.dask/config.yaml
@@ -1,0 +1,10 @@
+distributed:
+  logging:
+    bokeh: critical
+
+  dashboard:
+    link: "{JUPYTERHUB_BASE_URL}user/{JUPYTERHUB_USER}/proxy/{port}/status"
+
+  admin:
+    tick:
+      limit: 5s


### PR DESCRIPTION
This is helpful for binder, where the default localhost link doesn't work.

(File copied from github.com/dask/dask-examples.)

Test: https://mybinder.org/v2/gh/willirath/dask-tutorial/patch-1?urlpath=lab