### PR TITLE
Pin jupyterlab<3

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - nodejs
-  - jupyterlab>=2.0.0
+  - jupyterlab>=2.0.0,<3
   - numpy>=1.18.1
   - h5py
   - scipy>=1.3.0


### PR DESCRIPTION
Let's temporarily pin JupyterLab to <3.0 until the extensions used here have been updated to be 3.0-compatible. As @ian-r-rose pointed out in https://github.com/dask/dask-tutorial/issues/202#issuecomment-759796901, the `jupyter_bokeh` extension hasn't been updated yet but progress is being tracked at https://github.com/bokeh/bokeh/issues/10569

Closes https://github.com/dask/dask-tutorial/issues/202