### PR TITLE
Bump `dask` and `distributed` versions

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,9 +10,9 @@ dependencies:
   - scipy>=1.3.0
   - toolz
   - bokeh>=2.0.0
-  - dask=2.20.0
+  - dask=2021.08.0
   - dask-labextension>=2.0.0
-  - distributed=2.20.0
+  - distributed=2021.08.0
   - notebook
   - matplotlib
   - Pillow


### PR DESCRIPTION
This PR updates `dask` and `distributed` to a more recent release (`2.20.0` is over a year old at this point). The main benefit that comes to mind for the notebooks here are improved HTML reprs.

Note, `2021.08.0` was only released three days ago. If that's too recent, we can go with `2021.07.2` instead 