### PR TITLE
Use new Dask docs theme

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -c conda-forge nbconvert nbformat jupyter_client ipykernel
-          pip install nbsphinx dask-sphinx-theme sphinx
+          pip install nbsphinx dask-sphinx-theme>=2 sphinx
       - name: Build
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Bumping the minimum docs theme to use the new version. This isn't strictly necessary but I wanted to raise a PR to trigger the rtd preview and check everything looks ok.

xref dask/dask-sphinx-theme#54