### PR TITLE
Direct questions/discussion to Dask discourse group

### DIFF
--- a/00_overview.ipynb
+++ b/00_overview.ipynb
@@ -98,7 +98,7 @@
     "*  Ask for help\n",
     "    *   [`dask`](http://stackoverflow.com/questions/tagged/dask) tag on Stack Overflow, for usage questions\n",
     "    *   [github issues](https://github.com/dask/dask/issues/new) for bug reports and feature requests\n",
-    "    *   [gitter chat](https://gitter.im/dask/dask) for general, non-bug, discussion\n",
+    "    *   [discourse forum](https://dask.discourse.group/) for general, non-bug, questions and discussion\n",
     "    *   Attend a live tutorial"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This was already done for method c) and does not need repeating.
 *  Ask for help
     *   [`dask`](http://stackoverflow.com/questions/tagged/dask) tag on Stack Overflow, for usage questions
     *   [github issues](https://github.com/dask/dask/issues/new) for bug reports and feature requests
-    *   [gitter chat](https://gitter.im/dask/dask) for general, non-bug, discussion
+    *   [discourse forum](https://dask.discourse.group/) for general, non-bug, questions and discussion
     *   Attend a live tutorial
 
 ## Outline


### PR DESCRIPTION
I gave a tutorial today and noticed that the overview notebook directs people to the old, unused gitter chat. That link should be replaced with one to the new Dask discourse forum, which is more active: https://dask.discourse.group/

Closes https://github.com/dask/dask-tutorial/issues/221

Related:
- https://github.com/dask/dask/pull/8332
- https://github.com/dask/community/issues/194
