### PR TITLE
Use Jupyter Lab when running from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,5 @@ USER jovyan
 RUN git clone https://github.com/dask/dask-tutorial.git ./dask-tutorial
 RUN cd dask-tutorial && conda env update -n base -f binder/environment.yml --prune && . binder/postBuild && cd ..
 RUN rm dask-tutorial/github_deploy_key_dask_dask_tutorial.enc
+
+CMD jupyter lab


### PR DESCRIPTION
When running from Dockerfile (option 2c in the README), the Docker image build process installs Jupyter Lab, but the running container uses a regular Jupyter notebook unless the user specifically navigates to `localhost:8888/lab`.  The Jupyter notebook environment ignores `source_hidden` metadata so all the answers are visible, taking all the fun out of the exercises.

This PR modifies the Dockerfile to run Jupyter Lab instead.  As a result, the startup link redirects to `localhost:8888/lab`, where hidden cells are hidden correctly by default.