### PR TITLE
Avoid render error due to incomplete code

### DIFF
--- a/03_array.ipynb
+++ b/03_array.ipynb
@@ -651,7 +651,7 @@
     "```python\n",
     "result = ...\n",
     "fig = plt.figure(figsize=(16, 8))\n",
-    "plt.imshow(result cmap='RdBu_r')\n",
+    "plt.imshow(result, cmap='RdBu_r')\n",
     "```"
    ]
   },


### PR DESCRIPTION
The sample code in the exercise [in the docs](https://tutorial.dask.org/03_array.html#Exercise:-Meteorological-data) contains an 'error' when rendered on the website. The problem entry is this:

> # complete the following:
> fig = plt.figure(figsize=(16, 8))
> plt.imshow(..., cmap='RdBu_r')

As I understand, this is meant to be there as a fill-in exercise to be completed during tutorial, but to avoid the error in the rendered version, perhaps it can placed in a markdown block... (there might be a better way to deal with this, e.g. marking some cells to be ignored during execution, but since it's just one cell here, maybe that would be excessive)