### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -c conda-forge nbconvert nbformat jupyter_client ipykernel
-          pip install nbsphinx dask-sphinx-theme sphinx
+          pip install nbsphinx dask-sphinx-theme>=3.0.0 sphinx
       - name: Build
         shell: bash -l {0}
         run: |

--- a/conf.py
+++ b/conf.py
@@ -83,7 +83,9 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell