### PR TITLE
Synchronize readme and env spec and put pins in env to mildly future-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the main repo directory
 
 You will need the following core libraries
 
-    conda install -c conda-forge ipycytoscape jupyterlab python-graphviz matplotlib zarr xarray pooch scipy dask distributed 
+    conda install -c conda-forge ipycytoscape jupyterlab python-graphviz matplotlib zarr xarray pooch scipy dask distributed dask-labextension
 
 Note that these options will alter your existing environment, potentially changing the versions of packages you already
 have installed.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the main repo directory
 
 You will need the following core libraries
 
-    conda install numpy pandas h5py python-graphviz pillow matplotlib scipy toolz pytables snakeviz scikit-image dask distributed -c conda-forge
+    conda install -c conda-forge ipycytoscape jupyterlab python-graphviz matplotlib zarr xarray pooch scipy dask distributed 
 
 Note that these options will alter your existing environment, potentially changing the versions of packages you already
 have installed.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,33 +1,21 @@
-name: dask-tutorial-22
+name: dask-tutorial
 channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - nodejs
-  - jupyterlab>=2.0.0
-  - numpy>=1.18.1
-  - h5py
-  - holidays
-  - scipy>=1.3.0
-  - bokeh>=2.0.0
-  - dask=2022.06.1
+  - jupyterlab=2
+  - numpy=1.23
+  - scipy=1.8
+  - bokeh=2.4
+  - dask=2022.6.1
   - dask-labextension
-  - distributed=2022.06.1
-  - notebook
+  - distributed=2022.6.1
   - matplotlib
-  - pandas>=1.0.1
-  - pytables
-  - scikit-learn>=0.22.1
+  - pandas=1.4
   - pip
-  - s3fs
-  - pyarrow
-  - ipywidgets>=7.5
   - python-graphviz
   - ipycytoscape
   - zarr
-  - ipycytoscape
   - pooch
   - xarray
-  - jupyter_bokeh
   - mamba
-  - ipywidgets


### PR DESCRIPTION
I know I had said that maybe we didn't need to specify numpy and pandas, but then it occurred to me that this env is meant to last for years, so it is probably a good idea to try to future-proof it a bit using pins. 

I also removed a bunch of packages that we no longer depend on and made the `conda install...` in the readme match the env.