### PR TITLE
Update video to point to SciPy 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dask Tutorial
 
-This tutorial was last given at SciPy 2020 which was a virtual conference.
-[A video of the SciPy 2020 tutorial is available online](https://www.youtube.com/watch?v=EybGGLbLipI).
+This tutorial was last given at SciPy 2022 in Austin Texas.
+[A video of the SciPy 2022 tutorial is available online](https://youtu.be/J0NcbvkYPoE).
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dask/dask-tutorial/main?urlpath=lab)
 [![Build Status](https://github.com/dask/dask-tutorial/workflows/CI/badge.svg)](https://github.com/dask/dask-tutorial/actions?query=workflow%3ACI)


### PR DESCRIPTION
I think SciPy 2022 was the last time this was presented, but happy to be corrected.