### PR TITLE
Revert environment back to Python 3.10

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: dask-tutorial
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.10
   - jupyterlab=3
   - numpy=1.24
   - scipy=1.10


### PR DESCRIPTION
Looks like 3.11 isn't supported yet

<img width="807" alt="image" src="https://user-images.githubusercontent.com/1610850/214667651-bc637075-664b-40ed-8452-203343f2479b.png">

Rolling back to 3.10